### PR TITLE
Use Dir.pwd instead of File.dirname(__FILE__)

### DIFF
--- a/lib/stringer/processor.rb
+++ b/lib/stringer/processor.rb
@@ -38,7 +38,7 @@ module Stringer
     #
     # Returns the path
     def dir_path_for_dir_with_same_name_as_parent_dir
-      current_dir_path = File.dirname(__FILE__)
+      current_dir_path = Dir.pwd
       current_dir_name = File.basename(current_dir_path)
       File.join(current_dir_path, current_dir_name)
     end

--- a/specs/processor_spec.rb
+++ b/specs/processor_spec.rb
@@ -18,4 +18,13 @@ describe Stringer::Processor do
     end
 
   end
+
+  describe "setting the correct directories" do
+    it "should be started from the current directory" do
+      Dir.stubs(:pwd).returns('/Users/dev/Project1')
+
+      processor = Stringer::Processor.new("nl")
+      processor.dir_path_for_dir_with_same_name_as_parent_dir.must_equal "/Users/dev/Project1/Project1"
+    end
+  end
 end


### PR DESCRIPTION
Using File.dirname(**FILE**) returns the location of the library, which
is never what we want. This may have made sense when this code is in the
Rakefile, but not at this location. Leveraging Dir.pwd is a saner
default.
